### PR TITLE
Shutdown camera info sub after called

### DIFF
--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -259,6 +259,7 @@ void Camera::camInfoCallback (const sensor_msgs::CameraInfoConstPtr & cam_info)
         }
 		  
 		getCamInfo_ = true;
+		sub_.shutdown();
     }
   }
 


### PR DESCRIPTION
Disable camera info subscription after receiving the info.

This stops e. g. Asus Xtion from having an active subscription to the RGB image stream and thus saving CPU.
